### PR TITLE
Update autoprefixer dependency to over 6.5

### DIFF
--- a/material_components_web-sass.gemspec
+++ b/material_components_web-sass.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'autoprefixer-rails', '~> 6.5'
+  spec.add_runtime_dependency 'autoprefixer-rails', '>= 6.5'
   spec.add_runtime_dependency 'sass', '~> 3.4'
 
   spec.add_development_dependency 'railties', '~> 5.0'


### PR DESCRIPTION
Support for most recent version of Autoprefixer and prevent hickups with other gems using autoprefixer